### PR TITLE
Fix markdown table formatting issues 

### DIFF
--- a/internal/http/handler/webui/common/assets/templui.css
+++ b/internal/http/handler/webui/common/assets/templui.css
@@ -3932,6 +3932,37 @@
   border-top: 1px solid var(--border);
   margin: 1rem 0;
 }
+.prose table {
+  width: 100%;
+  caption-side: bottom;
+  font-size: 0.875rem;
+  margin: 0.75rem 0;
+}
+.prose thead tr {
+  border-bottom: 1px solid var(--border);
+}
+.prose tbody tr:last-child {
+  border-bottom: 0;
+}
+.prose tr {
+  border-bottom: 1px solid var(--border);
+  transition: background-color 0.15s;
+}
+.prose tr:hover {
+  background-color: color-mix(in srgb, var(--muted) 50%, transparent);
+}
+.prose th {
+  height: 2.5rem;
+  padding: 0 0.5rem;
+  text-align: left;
+  vertical-align: middle;
+  font-weight: 500;
+  color: var(--muted-foreground);
+}
+.prose td {
+  padding: 0.5rem;
+  vertical-align: middle;
+}
 .prose-sm {
   font-size: 0.875rem;
 }

--- a/internal/http/handler/webui/common/component/markdown.templ
+++ b/internal/http/handler/webui/common/component/markdown.templ
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 // Markdown renders markdown content with default prose styling.
@@ -22,8 +23,13 @@ templ MarkdownWithVariants(source string, class string) {
 }
 
 func convert(source string) (string, error) {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,
+		),
+	)
 	var buf bytes.Buffer
-	if err := goldmark.Convert([]byte(source), &buf); err != nil {
+	if err := md.Convert([]byte(source), &buf); err != nil {
 		return "", errors.WithStack(err)
 	}
 

--- a/internal/http/handler/webui/common/component/markdown_templ.go
+++ b/internal/http/handler/webui/common/component/markdown_templ.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 // Markdown renders markdown content with default prose styling.
@@ -110,8 +111,13 @@ func MarkdownWithVariants(source string, class string) templ.Component {
 }
 
 func convert(source string) (string, error) {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,
+		),
+	)
 	var buf bytes.Buffer
-	if err := goldmark.Convert([]byte(source), &buf); err != nil {
+	if err := md.Convert([]byte(source), &buf); err != nil {
 		return "", errors.WithStack(err)
 	}
 


### PR DESCRIPTION
This pull request enhances the Markdown rendering in the web UI by enabling support for GitHub Flavored Markdown (GFM) and improves the default styling for tables within Markdown content. The changes ensure that Markdown tables are rendered with better appearance and more consistent behavior, and that additional Markdown features (like tables, strikethrough, and task lists) are supported.

Markdown rendering improvements:

* Updated the Markdown conversion logic in both `markdown.templ` and `markdown_templ.go` to use `goldmark` with the `extension.GFM` extension, enabling GitHub Flavored Markdown features. [[1]](diffhunk://#diff-464fa95cefcdb4ed663879f2acabadc776112d882b3dd972bcdcabeb3e42cfabR8) [[2]](diffhunk://#diff-464fa95cefcdb4ed663879f2acabadc776112d882b3dd972bcdcabeb3e42cfabR26-R32) [[3]](diffhunk://#diff-f68b3c82fe929e0817b718239e7daaaffada91f2c0156964a731a6d26257bafaR16) [[4]](diffhunk://#diff-f68b3c82fe929e0817b718239e7daaaffada91f2c0156964a731a6d26257bafaR114-R120)

Styling enhancements:

* Added new CSS rules in `templui.css` to style tables within Markdown (`.prose table` and related selectors), improving table layout, borders, spacing, and hover effects.

Related issue https://github.com/Bornholm/corpus/issues/4